### PR TITLE
Revert "api networking.k8s.io/v1 was added"

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: snyk-broker
 description: Snyk Broker proxies access between snyk.io and your Git repositories
-version: 0.1.2
-appVersion: 4.126.2
+version: 0.1.1
+appVersion: 4.122.0
 sources:
   - https://github.com/snyk/broker

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,7 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-apiVersion: networking.k8s.io/v1
-{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
 apiVersion: networking.k8s.io/v1beta1
 {{ else }}
 apiVersion: extensions/v1beta1
@@ -25,16 +23,8 @@ spec:
     http:
       paths:
       - backend:
-        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-        pathType: Prefix
-          service:
-            name: {{ template "fullname" $ }}
-            port:
-              number: {{ $.Values.service.port }}      
-        {{ else }}
           serviceName: {{ template "fullname" $ }}
           servicePort: {{ $.Values.service.port }}
-        {{- end }}
         path: /
   {{- end }}
 {{- if .Values.ingress.tls }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 name: snyk-broker
 
 image:
-  tag: 4.126.2-gitlab
+  tag: 4.122.0-gitlab
   repository: snyk/broker
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Reverts DmitriyStoyanov/helm-chart-snyk-broker#1
Because of error
```
Error: UPGRADE FAILED: template: snyk-broker/templates/ingress.yaml:28:28: executing "snyk-broker/templates/ingress.yaml" at <.Capabilities.APIVersions.Has>: can't evaluate field Capabilities in type interface {}
```